### PR TITLE
Optimize dither_dhr.dither_image performance by about 2x

### DIFF
--- a/common.pxd
+++ b/common.pxd
@@ -1,5 +1,10 @@
 cdef float clip(float a, float min_value, float max_value) nogil
 
-cdef float[::1] convert_rgb_to_cam16ucs(float[:, ::1] rgb_to_cam16ucs, float r, float g, float b) nogil
+# This is used to avoid passing around float[::1] memoryviews in the critical path.  These seem to
+# require reference counting which has a large performance overhead.
+cdef packed struct float3:
+    float[3] data
 
-cdef double colour_distance_squared(float[::1] colour1, float[::1] colour2) nogil
+cdef float3 convert_rgb_to_cam16ucs(float[:, ::1] rgb_to_cam16ucs, float r, float g, float b) nogil
+
+cdef float colour_distance_squared(float[3] colour1, float[3] colour2) nogil

--- a/common.pyx
+++ b/common.pyx
@@ -4,20 +4,28 @@
 # cython: wraparound=False
 
 
-cdef float clip(float a, float min_value, float max_value) nogil:
+cdef inline float clip(float a, float min_value, float max_value) nogil:
     """Clip a value between min_value and max_value inclusive."""
     return min(max(a, min_value), max_value)
 
 
-cdef inline float[::1] convert_rgb_to_cam16ucs(float[:, ::1] rgb_to_cam16ucs, float r, float g, float b) nogil:
+cdef inline float3 convert_rgb_to_cam16ucs(float[:, ::1] rgb_to_cam16ucs, float r, float g, float b) nogil:
     """Converts floating point (r,g,b) valueto 3-tuple in CAM16UCS colour space, via 24-bit RGB lookup matrix."""
 
     cdef unsigned int rgb_24bit = (<unsigned int>(r*255) << 16) + (<unsigned int>(g*255) << 8) + <unsigned int>(b*255)
-    return rgb_to_cam16ucs[rgb_24bit]
+    cdef float3 res
+    cdef int i
+    for i in range(3):
+        res.data[i] = rgb_to_cam16ucs[rgb_24bit][i]
+    return res
 
 
-cdef inline double colour_distance_squared(float[::1] colour1, float[::1] colour2) nogil:
+cdef inline float colour_distance_squared(float[3] colour1, float[3] colour2) nogil:
     """Computes Euclidean squared distance between two floating-point colour 3-tuples."""
 
-    return (colour1[0] - colour2[0]) ** 2 + (colour1[1] - colour2[1]) ** 2 + (colour1[2] - colour2[2]) ** 2
+    return (
+        (colour1[0] - colour2[0]) * (colour1[0] - colour2[0]) +
+        (colour1[1] - colour2[1]) * (colour1[1] - colour2[1]) +
+        (colour1[2] - colour2[2]) * (colour1[2] - colour2[2])
+    )
 


### PR DESCRIPTION
- avoid passing around a float[::1] memoryview across function barriers, this seems to require reference counting which has a large overhead
- inline some functions
- C division